### PR TITLE
filter input files per extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ plugins:
       diagram_root: "docs/diagrams" # should reside under docs_dir
       output_folder: "out"
       input_folder: "src"
+      input_extensions: "" # comma separated list of extensions to parse, by default every file is parsed
 ```
 
 It is recommended to use the `server` option, which is much faster than `local`.


### PR DESCRIPTION
Hi,

I needed a way to limit which files are parsed by the plugin as I prefer to mix my plantuml files and my markdown files.

In order to do this, I added a new configuration parameter that allows filtering which files to parse based on their extensions (for example only .puml files)

this should fix #7 

